### PR TITLE
Update DPARSFA_run.m

### DIFF
--- a/DPARSFA_run.m
+++ b/DPARSFA_run.m
@@ -1059,6 +1059,7 @@ if (AutoDataProcessParameter.IsNeedT1CoregisterToFun==1)
                 end
             else %4D .nii images
                 [Data, Header] = rest_ReadNiftiImage(DirImg(1).name);
+                AllVolume = Data;                                          %added by ORSOLINI ~ 12 february 2013
             end
             
             AllVolume=mean(AllVolume,4);


### PR DESCRIPTION
error message:
??? Undefined function or variable "AllVolume".
Error in ==> DPARSFA_run_mod at 1065
            AllVolume=mean(AllVolume,4);

the 4D matrix was named "Data" but computation is made over "AllVolume"
now the mean-functional it is computed and saved correctly.
